### PR TITLE
Fix after "Send To GPS" is removed

### DIFF
--- a/send2cgeoOc.user.js
+++ b/send2cgeoOc.user.js
@@ -60,13 +60,12 @@ document.getElementsByTagName("head")[0].appendChild(s);
 	document.getElementsByTagName("body")[0].appendChild(b);
 	
   // Append to send2cgeo links/buttons /////////////////////////////////////////
-  var oc = document.getElementsByClassName('exportbutton')[0].parentNode.parentNode;
+  var oc = document.getElementsByClassName('exportlist')[0].parentNode.parentNode;
 
   if(oc !== null) {
     
-	var occode=oc.innerHTML;
-	var wppos = occode.indexOf('wp=');
-	occode = occode.substring(wppos+3,occode.indexOf("'", wppos+3));
+	var occode = document.title;
+	occode = occode.substring(0,occode.indexOf(" ", 0));
 	
     var html = '<img src="resource2/ocstyle/images/viewcache/14x19-gps-device.png" class="icon16" alt="" />'
 			 + '<a class="send-to-gps" '


### PR DESCRIPTION
The "Send To GPS" button probably will be removed from the cache page.

This PR only works on the test server at the moment as the button has already been removed there. For this reason, merging should be done after the button has been removed from the "normal" site, too. Otherwise it would not work on the "normal" site anymore.