### PR TITLE
Fix #36 - Use working PMcheck and column fix

### DIFF
--- a/send2cgeo.user.js
+++ b/send2cgeo.user.js
@@ -19,7 +19,7 @@
 // @downloadURL    https://github.com/cgeo/send2cgeo/raw/release/send2cgeo.user.js
 // @updateURL      https://github.com/cgeo/send2cgeo/raw/release/send2cgeo.user.js
 // @supportURL     https://github.com/cgeo/send2cgeo/issues
-// @version        0.39
+// @version        0.40
 // ==/UserScript==
 
 // Inserts javascript that will be called by the s2cgeo button. The closure
@@ -28,28 +28,6 @@
 // accessed.
 
 var s       = document.createElement('script');
-
-// check for premium membership (parts of the page content are different)
-var premium;
-if (document.getElementsByClassName('li-membership').length) {
-    premium = document.getElementsByClassName('li-membership')[0];
-} else if (document.getElementsByClassName('li-upgrade').length) {
-    premium = document.getElementsByClassName('li-upgrade')[0];
-} else {
-    premium = true;
-}
-
-// premium has either an empty <li class="li-upgrade">
-// or none of li-membership / li-upgrade present
-if (premium != true && premium.children.length) {
-    // in case GC.com changes the content,
-    // it still has to contain only "Upgrade" string
-    if (premium.children[0].innerHTML == 'Upgrade') {
-        premium = false;
-    }
-} else {
-    premium = true;
-}
 
 s.type      = 'text/javascript';
 s.textContent =  '(' + function() {
@@ -71,6 +49,31 @@ s.textContent =  '(' + function() {
       });
   };
 
+  // check for premium membership (parts of the page content are different)
+  function premiumCheck() {
+      var premium;
+      if (document.getElementsByClassName('li-membership').length) {
+          premium = document.getElementsByClassName('li-membership')[0];
+      } else if (document.getElementsByClassName('li-upgrade').length) {
+          premium = document.getElementsByClassName('li-upgrade')[0];
+      } else {
+          premium = true;
+      }
+
+      // premium has either an empty <li class="li-upgrade">
+      // or none of li-membership / li-upgrade present
+      if (premium != true && premium.children.length) {
+          // in case GC.com changes the content,
+          // it still has to contain only "Upgrade" string
+          if (premium.children[0].innerHTML == 'Upgrade') {
+              premium = false;
+          }
+      } else {
+          premium = true;
+      }
+      return premium;
+  }
+
   // this adds a column with send2cgeo button in search results table
   function addSend2cgeoColumn(field) {
         var GCCode = $(field).text();
@@ -83,12 +86,7 @@ s.textContent =  '(' + function() {
             + 'border="0"> '
             + '</a></td>';
 
-        // check for premium (different columns)
-        if (window.premium) {
             $(field).parent().parent().before(html);
-        } else {
-            $(field).parent().parent().after(html);
-        }
   }
 
   // waits for new elements (by ajax calls) injected into the DOM and calls a certain
@@ -191,13 +189,13 @@ s.textContent =  '(' + function() {
 
     // Send 2 cgeo column header for func addSend2cgeoColumn
     var S2CGHeader = '<th class="mobile-show"><a class="outbound-link">Send to c:geo</a></th>';
-    if (window.premium) {
-      $("#searchResultsTable th:nth-child(2)").after(S2CGHeader);
-      $("#searchResultsTable col:nth-child(2)").after('<col></col>');
-    } else {
+    if (premiumCheck()) {
       $("#searchResultsTable th").first().after(S2CGHeader);
       $("#searchResultsTable col").first().after('<col></col>');
-    }
+    } else {
+      $("#searchResultsTable th").first().before(S2CGHeader);
+      $("#searchResultsTable col").first().before('<col></col>');
+}
 
     var caches = $(".cache-details");
     caches.each(addSend2cgeoColumn);


### PR DESCRIPTION
Original PM check was not working and replaced by a function (credits to @KeyWeeUsr).

On new search page the send2cgeo icon is now always shown left of the cache name, which means it is only the second column for PM due to the checkboxes not present on the BM page.