### PR TITLE
Made send2cgeo button look like download gpx button

### DIFF
--- a/send2cgeo.user.js
+++ b/send2cgeo.user.js
@@ -269,11 +269,10 @@ s.textContent =  '(' + function() {
     var GCCode = $('#ctl00_ContentBody_CoordInfoLinkControl1_uxCoordInfoCode')
                   .html();
 
-    var html = '<input type="button" '
-             + 'value="Send to c:geo" '
-             + 'onclick="window.s2geo(\''+GCCode+'\'); '
-             + 'return false;" '
-             + '/>';
+    var html = '<dt class="label">'
+             + '<a id="ctl00_ContentBody_lnkGpxDownload" onclick="window.s2geo(\''+GCCode+\''); return false;"><span id="ctl00_ContentBody_uxDownloadLabel">Send to c:geo</span></a>'
+	     + '</dt>'
+
 
     $('#Download p:last').append(html);
     $('#Download dd:last').append(html);

--- a/send2cgeo.user.js
+++ b/send2cgeo.user.js
@@ -270,7 +270,7 @@ s.textContent =  '(' + function() {
                   .html();
 
     var html = '<dt class="label">'
-             + '<a id="ctl00_ContentBody_lnkGpxDownload" onclick="window.s2geo(\''+GCCode+\''); return false;"><span id="ctl00_ContentBody_uxDownloadLabel">Send to c:geo</span></a>'
+             + '<a id="ctl00_ContentBody_lnkGpxDownload" onclick="window.s2geo(\''+GCCode+'\'); return false;"><span id="ctl00_ContentBody_uxDownloadLabel">Send to c:geo</span></a>'
 	     + '</dt>'
 
 


### PR DESCRIPTION
This changes the HTML injected in the geocache detail page to look "native" like the "download GPX" button instead of just a default button