### PR TITLE
premiumCheck and alignment at the new search

### DIFF
--- a/send2cgeo.user.js
+++ b/send2cgeo.user.js
@@ -161,7 +161,7 @@ function s2cgGCMain() {
         if (premium !== true && premium.children.length) {
             // in case GC.com changes the content,
             // it still has to contain only "Upgrade" string
-            if (premium.children[0].innerHTML == 'Upgrade') {
+            if (premium.children[0].getAttribute('data-event-label') == 'Upgrade CTA') {
                 premium = false;
             }
         } else {
@@ -379,6 +379,7 @@ function s2cgGCMain() {
         } else {
             $("#searchResultsTable th").first().before(S2CGHeader);
             $("#searchResultsTable col").first().before('<col></col>');
+            $('head').append('<style type="text/css">tr[data-premium] td + td {padding: 0 !important;}</style>');
         }
 
         var caches = $(".cache-details");


### PR DESCRIPTION
- fix #93 Now PremiumCheck() works again and in every language
- fix #44 No misalignment in the new search for PM-Caches