### PR TITLE
use eslint config file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "quotes": ["error", "single", { "avoidEscape": true }]
+    }
+}


### PR DESCRIPTION
test if a eslintrc* config is helpful for the `Strings must use doublequote.` lint result on codacy.