### PR TITLE
Send multiple caches

### DIFF
--- a/send2cgeo.user.js
+++ b/send2cgeo.user.js
@@ -3,8 +3,8 @@
 // @namespace      http://send2.cgeo.org/
 // @description    Add button "Send to c:geo" to geocaching.com and opencaching.de
 // @author         c:geo team and contributors
-// @require        http://code.jquery.com/jquery-3.4.1.min.js
-// @include        /^https?://www\.geocaching\.com/play/(search|map)/
+// @require        http://code.jquery.com/jquery-3.5.1.min.js
+// @include        /^https?://www\.geocaching\.com/play/(search|map|owner)/
 // @include        /^https?://www\.geocaching\.com/play/owner/(published|unpublished|archived)/
 // @include        /^https?://www\.geocaching\.com/play/owner/(published|unpublished|archived)/events/
 // @include        /^https?://www\.geocaching\.com/seek/(cache_details\.|nearest\.|)/
@@ -21,6 +21,8 @@
 // @grant          GM_setValue
 // @grant          GM_getValue
 // ==/UserScript==
+
+'use strict';
 
 // Function that handles the actual sending
 // The window.s2geo() functions have to be insert into the pagehead, so that they be called with onclick="window.s2geo"
@@ -54,73 +56,6 @@ s2cgScript.innerHTML = 'window.s2geo = function(GCCode) {'
     + '};';
 
 document.getElementsByTagName('head')[0].appendChild(s2cgScript);
-
-var s2geomultiScript = document.createElement('script');
-s2geomultiScript.type = 'text/javascript';
-s2geomultiScript.innerHTML = ''
-    + 'window.s2geomulti = function(requestedCnt, skipFound, moreClicked) {'
-    + '    if (typeof(skipFound) == "undefined" ) {'
-    + '        skipFound = $("#send2cgeo_skip_found").is(":checked");'
-    + '    }'
-    + '    var alreadySent = $("[send2cgeo_sent]").length;'
-    + '    if (alreadySent < requestedCnt) {'
-    + '        var toAddIframe = $("[send2cgeo_gccode]").not("[send2cgeo_sent]").first();'
-    + '        if (toAddIframe.length) {'
-    + '            s2geomultiProcessLine(toAddIframe, skipFound, requestedCnt, alreadySent);'
-    + '        } else {'
-    + '            s2geomultiLoadMore(requestedCnt, alreadySent, skipFound, moreClicked);'
-    + '        }'
-    + '    } else {'
-    + '        s2cgeoProgressReport("Finished after sending " + alreadySent + " caches.");'
-    + '    }'
-    + '};'
-
-    + 'function s2cgeoProgressReport(message, append) {'
-    + '    if (append) {'
-    + '        $("#send2cgeo_controls_div").append(message);'
-    + '    } else {'
-    + '        $("#send2cgeo_controls_div").html(message);'
-    + '    }'
-    + '}'
-
-    + 'function s2geomultiLoadMore(requestedCnt, alreadySent, skipFound, moreClicked) {'
-    + '    if (!moreClicked) {'
-    + '        s2cgeoProgressReport("Waiting to load more caches from web site, sent " + alreadySent + " caches.", false);'
-    + '        var loadMoreBtn = $("#loadmore");'
-    + '        loadMoreBtn.click();'
-    + '        moreClicked = true;'
-    + '    }'
-    + '    s2cgeoProgressReport(".", true);'
-    + '    setTimeout('
-    + '        function() {'
-    + '            s2geomulti(requestedCnt, skipFound, moreClicked);'
-    + '        },'
-    + '        2000'
-    + '    );'
-    + '}'
-
-    + 'function s2geomultiProcessLine(toAddIframe, skipFound, requestedCnt, alreadySent) {'
-    + '    if (skipFound) {'
-    + '        if (toAddIframe.parent().parent().find(\'use[xlink\\\\:href*="#icon-found"]\').length === 0) {'
-    + '             var GCCode = toAddIframe.attr("send2cgeo_gccode");'
-    + '             toAddIframe.html("<iframe width=120 height=80 src=\'https://send2.cgeo.org/add.html?cache="+GCCode+"\'>");'
-    + '             toAddIframe.attr("send2cgeo_sent","1");'
-    + '             s2cgeoProgressReport((alreadySent+1)+" ",alreadySent!==0);'
-    + '        } else {'
-    + '            var trToDel = toAddIframe.parent().parent();'
-    + '            trToDel.remove();'
-    + '            s2cgeoProgressReport(".",alreadySent!==0);'
-    + '        }'
-    + '    }'
-    + '    setTimeout('
-    + '        function() {'
-    + '            s2geomulti(requestedCnt, skipFound, false);'
-    + '        },'
-    + '        100'
-    + '    );'
-    + '};';
-
-document.getElementsByTagName('head')[0].appendChild(s2geomultiScript);
 
 // This solves the problems with jquery
 var quitOnAdFrames = function() {
@@ -165,7 +100,7 @@ function isUseWithoutThirdPartyCookies() {
 
 function s2cgGCMain() {
     // check for premium membership (parts of the page content are different)
-    function premiumCheck() {
+    function isPremium() {
         var premium;
         if (document.getElementsByClassName('li-membership').length) {
             premium = document.getElementsByClassName('li-membership')[0];
@@ -191,18 +126,19 @@ function s2cgGCMain() {
 
     // this adds a column with send2cgeo button in search results table
     function addSend2cgeoColumn(field) {
-        var GCCode = $(field).text();
-        GCCode = GCCode.slice(GCCode.indexOf("|") + 1).trim();
-        if (document.getElementById('s2cg-' + GCCode)) {
+        if (field == 0) {
+            return;
+        }
+        var GCCode = $(field).html().match(/GC[A-Z0-9]{1,6}/)[0];
+        if ($('s2cg-' + GCCode)[0]) {
             return;
         }
 
-        var html = '<td class="mobile-show" >'
-            + '<a id="s2cg-' + GCCode + '" href="https://send2.cgeo.org/add.html?cache=' + GCCode + '" '
-            + "onclick='window.s2geo(\"" + GCCode + "\"); return false;' send2cgeo_gccode='" + GCCode + "'>"
-            + '<img height="50" src="https://www.cgeo.org/send2cgeo.png" '
-            + 'border="0"> '
-            + '</a></td>';
+        var html = '<td class="mobile-show">'
+            + '    <a id="s2cg-' + GCCode + '" href="javascript:void(0);" onclick="window.s2geo(\'' + GCCode + '\'); return false;">'
+            + '        <img height="50" src="https://www.cgeo.org/send2cgeo.png" border="0"> '
+            + '    </a>'
+            + '</td>';
 
         $(field).parent().parent().before(html);
     }
@@ -216,7 +152,7 @@ function s2cgGCMain() {
         if (typeof iframeSelector == "undefined") {
             targetNodes = $(selectorTxt);
         } else {
-            targetNodes = $(iframeSelector).contents().find (selectorTxt);
+            targetNodes = $(iframeSelector).contents().find(selectorTxt);
         }
         if (targetNodes && targetNodes.length > 0) {
             btargetsFound = true;
@@ -250,7 +186,7 @@ function s2cgGCMain() {
         if (btargetsFound && bWaitOnce && timeControl) {
             // The only condition where we need to clear the timer
             clearInterval(timeControl);
-            delete controlObj[controlKey]
+            delete controlObj[controlKey];
         } else {
             // Set a timer, if needed
             if (! timeControl) {
@@ -274,52 +210,37 @@ function s2cgGCMain() {
     }
 
     // Send List
-    function sendList(whatSend) {
-        removeIfAlreadyExists('#s2cgeo-process', $('#s2cgeo-process'));
-        var alreadySend = 0;
-        $('.section-controls').after('<div id="s2cgeo-process"></div>');
-        // Send selected
-        if (whatSend == 'selected') {
-            var caches = $.find('.geocache-table tbody tr');
-            $(caches).each(
-                function() {
-                    if ($(this).find('.gc-checkbox').hasClass('checked')) {
-                        var text = $(this).find('.geocache-code').text().split('|');
-                        var GCCode = text[1].trim();
-                        $(this).attr('s2cgeo-send', GCCode);
-                    }
-                }
+    function sendList(list, i=0) {
+        if (list == undefined || list == null || (!Array.isArray(list) && list.length == 0)) {
+            return;
+        }
+        var GCCode = list[i];
+        if (isUseWithoutThirdPartyCookies()) {
+            var padding = i%10 * 30 + 10;
+            let sendCache = window.open(
+                'https://send2.cgeo.org/add.html?cache=' + GCCode,
+                'send' + GCCode,
+                'width=200,height=100,top=' + padding + ',left=' + padding + ',menubar=no,status=no,resizable=no;'
             );
+            window.setTimeout(
+                function() {
+                    sendCache.close();
+                },
+                3000
+            );
+        } else {
+            let iframe = '<iframe name="' + GCCode + '" src=\"https://send2.cgeo.org/add.html?cache=' + GCCode + '\" width="80" height="55">';
+            $('#s2cg-' + GCCode).parent().html(iframe);
         }
-
-        // Sending
-        var cachesToSend = $('[s2cgeo-send]');
-        function sendCache(i) {
-            var GCCode = $(cachesToSend[i]).attr('s2cgeo-send');
-            if (isUseWithoutThirdPartyCookies()) {
-                var padding = i%10 * 30 + 10;
-                let sendCache = window.open('https://send2.cgeo.org/add.html?cache=' + GCCode, 'send' + GCCode, 'width=200,height=100,top=' + padding +',left=' + padding + ',menubar=no,status=no');
-                window.setTimeout(
-                    function() {
-                        sendCache.close();
-                    },
-                    900
-                );
-            } else {
-                $(cachesToSend[i]).find('.s2cgeo').html('<iframe name="' + GCCode + '" src=\"https://send2.cgeo.org/add.html?cache=' + GCCode + '\" width="80" height="55">');
-            }
-            alreadySend++;
-            $('#s2cgeo-process').html(alreadySend + '/' + cachesToSend.length + ' caches sent');
-            if (i+1 < cachesToSend.length) {
-                window.setTimeout(
-                    function () {
-                        sendCache(i+1);
-                    },
-                    100
-                )
-            }
+        $('#s2cg_send_process').html((i+1) + '/' + list.length + ' caches sent');
+        if (i+1 < list.length) {
+            window.setTimeout(
+                function () {
+                    sendList(list, i+1);
+                },
+                100
+            )
         }
-        sendCache(0)
     }
 
     // This function add the send2cgeo buttons on geocaching.com
@@ -368,7 +289,7 @@ function s2cgGCMain() {
 
     var boxStyle = 'display:none; background:#1D1D1D; z-index:1010; left:50%; '
         + 'box-shadow:0 0 0.5em #000; padding:0; border:0; '
-        + 'position:fixed; top:0.5em;  text-align:center; '
+        + 'position:fixed; top:6em;  text-align:center; '
         + 'margin-left:-' + (boxWidth/2) + 'em; line-height:' + boxHeight + 'em; '
         + 'width:' + boxWidth + 'em; height:' + boxHeight + 'em; color: #fff';
     var waitStyle = 'width: ' + boxWidth + 'em; color: #fff';
@@ -397,10 +318,10 @@ function s2cgGCMain() {
     // Send to c:geo on seachmap (new map)
     if (document.location.href.match(/\.com\/play\/map/)) {
         function addButton() {
-            if (document.querySelector('.cache-preview-action-menu')) {
+            if ($('.cache-preview-action-menu')[0]) {
                 var GCCode = $('.cache-metadata-code').html();
-                // Break when a button with the GCCode already exist
-                if (document.getElementById('s2cg-' + GCCode)) {
+                // Return when a button with the GCCode already exist
+                if ($('s2cg-' + GCCode)[0]) {
                     return;
                 }
                 // Remove button when the GCCode has change
@@ -456,17 +377,91 @@ function s2cgGCMain() {
 
         window.waitForKeyElements(".cache-details", addSend2cgeoColumn, false);
 
-        $("#searchResultsTable").before(
-            "<div id='send2cgeo_controls_div'><a href=\"#\" onclick=\"window.s2geomulti(50); return false;\">Send2cgeo: 50</a> "
-                + "<a href=\"#\" onclick=\"window.s2geomulti(100); return false;\">100</a> "
-                + "<a href=\"#\" onclick=\"window.s2geomulti(200); return false;\">200</a> "
-                + "<a href=\"#\" onclick=\"window.s2geomulti(500); return false;\">500</a> "
-                + "<label><input checked='true' style='display:block' type='checkbox' id='send2cgeo_skip_found' name='send2cgeo_skipt_found'><span class=\"label\">Skip found caches</span></label></div>"
+        function getGCCodes(number, skipFound) {
+            var skiped = 0;
+            var gccodes = new Array();
+            var loadMore = true;
+            var numberOfAllCaches = $('.controls-header').html().replace(/[\.,]/g, '').match(/\d{1,}/);
+            var maxCaches = (numberOfAllCaches >= 1000 ? 1000 : numberOfAllCaches);
+            function addGCCode(i, skipFound) {
+                let tr = $('#geocaches tr')[i];
+                if (tr) {
+                    loadMore = true;
+                    if (!skipFound || (skipFound && (!$(tr).find('svg.badge')[0] || !$(tr).find('svg.badge use').attr('xlink:href').match(/#icon-found/)))) {
+                        gccodes.push($(tr).attr('data-id'));
+                    } else {
+                        skiped++;
+                    }
+                    $('#s2cg_send_process').html((number == 0 ? 0 : (i+1-skiped)) + '/' + number + ' caches load');
+                    if (i+1 < number+skiped) {
+                        addGCCode(i+1, skipFound);
+                    } else {
+                        // All Caches Load
+                        sendList(gccodes);
+                    }
+                } else {
+                    function waitAndAdd(i, skipFound) {
+                        window.setTimeout(
+                            function () {
+                                addGCCode(i, skipFound);
+                            },
+                            300
+                        );
+                    }
+                    if ($('#loadmore')[0] && loadMore) {
+                        loadMore = false;
+                        $('#loadmore').click();
+                        waitAndAdd(i, skipFound)
+                    } else {
+                        if (i == maxCaches) {
+                            // The maximum of 1000 caches is load
+                            $('#s2cg_send_process').html('The maximum number of caches has been loaded.');
+                            window.setTimeout(
+                                function () {
+                                    sendList(gccodes);
+                                },
+                                500
+                            );
+                        } else {
+                            waitAndAdd(i, skipFound);
+                        }
+                    }
+                }
+            }
+            addGCCode(0, skipFound);
+        }
+
+        $('#searchResultsTable').before(
+            '<div>Send2cgeo: '
+            + '    <a href="javascript:void(0);" id="send_50">50</a> '
+            + '    <a href="javascript:void(0);" id="send_100">100</a> '
+            + '    <a href="javascript:void(0);" id="send_200">200</a> '
+            + '    <a href="javascript:void(0);" id="send_500">500</a> '
+            + '    <a href="javascript:void(0);" id="send_1000">1000</a> '
+            + '    <label style="display:block"><input type="checkbox" id="send2cgeo_skip_found" name="send2cgeo_skipt_found"><span>Skip found caches</span></label>'
+            + '    <div id="s2cg_send_process"></div>'
+            + '</div>'
         );
+
+        $('#send_50').on('click', function() {
+            getGCCodes(50, $('#send2cgeo_skip_found').is(':checked'));
+        });
+        $('#send_100').on('click', function() {
+            getGCCodes(100, $('#send2cgeo_skip_found').is(':checked'));
+        });
+        $('#send_200').on('click', function() {
+            getGCCodes(200, $('#send2cgeo_skip_found').is(':checked'));
+        });
+        $('#send_500').on('click', function() {
+            getGCCodes(500, $('#send2cgeo_skip_found').is(':checked'));
+        });
+        $('#send_1000').on('click', function() {
+            getGCCodes(1000, $('#send2cgeo_skip_found').is(':checked'));
+        });
 
         // Send2cgeo column header for func addSend2cgeoColumn
         var S2CGHeader = '<th class="mobile-show"><a class="outbound-link">Send to c:geo</a></th>';
-        if (premiumCheck()) {
+        if (isPremium()) {
             $("#searchResultsTable th").first().after(S2CGHeader);
             $("#searchResultsTable col").first().after('<col></col>');
         } else {
@@ -495,8 +490,7 @@ function s2cgGCMain() {
         $('.BorderTop th').first().after('<th><img src="https://www.cgeo.org/send2cgeo.png" title="Send to c:geo" height="20px" /></th>');
         $('.Data.BorderTop').each(
             function() {
-                var text = $(this).find(".Merge").last().find("span.small").first().text().split("|");
-                var GCCode = text[text.length - 2].trim();
+                var GCCode = $(this).find(".Merge").last().find("span.small").first().text().match(/GC[A-Z0-9]{1,6}/)[0];
                 var html = '<td><a href="javascript:void(0);" onclick="window.s2geo(\'' + GCCode + '\'); return false;">'
                     + '    <img src="https://www.cgeo.org/send2cgeo.png" title="Send to c:geo" height="20px" />'
                     + '</a></td>';
@@ -529,17 +523,28 @@ function s2cgGCMain() {
             observer.disconnect();
 
             if ($('.multi-select-action-bar')[0]) {
-                removeIfAlreadyExists('#s2cgeo-selected', $('#s2cgeo-selected'));
-                $('.multi-select-action-bar-count-section').after('<a id="s2cgeo-selected" href="javascript:void(0);">'
+                removeIfAlreadyExists('#s2cg_selected', $('#s2cg_selected'));
+                $('.multi-select-action-bar-count-section').after('<a id="s2cg_selected" href="javascript:void(0);">'
                     + '    <img src="https://www.cgeo.org/send2cgeo.png" title="Send to c:geo" height="45px" style="margin-right:8px" />'
                     + '</a>');
-                $('#s2cgeo-selected').on('click', function() {
-                    sendList('selected');
+                $('#s2cg_selected').on('click', function() {
+                    var caches = $.find('.geocache-table tbody tr input[type="checkbox"]:checked');
+                    var gccodes = new Array();
+                    $(caches).each(
+                        function() {
+                            let GCCode = $(this).parents('tr').find('.geocache-code').text().match(/GC[A-Z0-9]{1,6}/)[0];
+                            gccodes.push(GCCode);
+                        }
+                    );
+                    sendList(gccodes);
                 });
+                if (!$('#s2cg_send_process')[0] || $('#s2cg_send_process').html() == '') {
+                    $('.section-controls').after('<div id="s2cg_send_process"></div>');
+                }
             }
 
-            removeIfAlreadyExists('.header-s2cgeo', $('.header-s2cgeo'));
-            $('.geocache-table thead th.header-geocache-name').before('<th class="header-s2cgeo"><img src="https://www.cgeo.org/send2cgeo.png" title="Send to c:geo" height="20px" /></th>');
+            removeIfAlreadyExists('.header-s2cg', $('.header-s2cg'));
+            $('.geocache-table thead th.header-geocache-name').before('<th class="header-s2cg"><img src="https://www.cgeo.org/send2cgeo.png" title="Send to c:geo" height="20px" /></th>');
 
             $('.geocache-table tbody tr').each(
                 function() {
@@ -552,13 +557,12 @@ function s2cgGCMain() {
                         }
                         return;
                     }
-                    var text = $(this).find('.geocache-code').text().split('|');
-                    var GCCode = text[1].trim();
+                    var GCCode = $(this).find('.geocache-code').text().match(/GC[A-Z0-9]{1,6}/)[0];
 
                     removeIfAlreadyExists('#s2cg-' + GCCode, $('#s2cg-' + GCCode).parent());
 
-                    $(this).find('td.cell-geocache-name').before('<td class="s2cgeo"></td>');
-                    buildButton(GCCode, $(this).find('td.s2cgeo'), '20px');
+                    $(this).find('td.cell-geocache-name').before('<td class="s2cg"></td>');
+                    buildButton(GCCode, $(this).find('td.s2cg'), '20px');
                 }
             );
             // continue observing
@@ -570,7 +574,7 @@ function s2cgGCMain() {
         // observer callback
         let cb = function() {
             // add buttons if table has been loaded
-            if ($('.section-controls').length > 0) {
+            if ($('.geocache-table tbody tr').length > 0) {
                 addButtons();
             }
         }
@@ -588,19 +592,17 @@ function s2cgGCMain() {
             // stop observing during adding the buttons
             observer.disconnect();
 
-            removeIfAlreadyExists('.header-s2cgeo', $('.header-s2cgeo'));
-            $('.geocache-table thead th.header-name').before('<th class="header-s2cgeo"><img src="https://www.cgeo.org/send2cgeo.png" title="Send to c:geo" height="20px" /></th>');
+            removeIfAlreadyExists('.header-s2cg', $('.header-s2cg'));
+            $('.geocache-table thead th.header-name').before('<th class="header-s2cg"><img src="https://www.cgeo.org/send2cgeo.png" title="Send to c:geo" height="20px" /></th>');
 
             $('.geocache-table tbody tr').each(
                 function() {
-                    var text = $(this).find('.geocache-details').text().split('|');
-                    text = text[0].trim();
-                    var GCCode = text.substr(0, text.length-3).trim();
+                    var GCCode = $(this).find('.geocache-details').text().match(/GC[A-Z0-9]{1,6}/)[0];
 
                     removeIfAlreadyExists('#s2cg-' + GCCode, $('#s2cg-' + GCCode).parent());
 
-                    $(this).find('td.name-display').before('<td class="s2cgeo"></td>');
-                    buildButton(GCCode, $(this).find('td.s2cgeo'), '20px');
+                    $(this).find('td.name-display').before('<td class="s2cg"></td>');
+                    buildButton(GCCode, $(this).find('td.s2cg'), '20px');
                 }
             );
 
@@ -613,8 +615,7 @@ function s2cgGCMain() {
     // Send to c:geo on viewcache
     if(document.location.href.match(/\.de\/viewcache\.php/)) {
         var oc = document.getElementsByClassName('exportlist')[0].parentNode.parentNode;
-        var occode = document.title;
-        occode = occode.substring(0, occode.indexOf(" ", 0));
+        var occode = document.title.match(/OC[A-Z0-9]{1,6}/)[0];
 
         var html = '<img src="https://www.cgeo.org/send2cgeo.png" height="16px" />'
             + '<a href="javascript:void(0);" onclick="window.s2geo(\'' + occode + '\'); return false;" >&nbsp;'
@@ -624,42 +625,15 @@ function s2cgGCMain() {
         oc.innerHTML = oc.innerHTML.replace('</p>', html);
     }
 
-    if (document.location.href.match(/\.de\/map2.php/)) {
-        function addButton() {
-            // stop observing during adding the buttons
-            observer.disconnect();
+// Bild a s2cg popup
+    var popupHTML = '<div id="s2cg_popup" style="display:none;">'
+                  + '    <div id="s2cg_popup_content">'
+                  + '    </div>'
+                  + '</div>';
 
-            removeIfAlreadyExists('#s2cg', $('#s2cg'));
-
-            var row = ($('#mapinfowindow table.mappopup tr:nth-child(1) td')[2] ? 1 : 2);
-
-            var OCCode = $('#mapinfowindow table.mappopup tr:nth-child('+row+') td:nth-child(3) font b')[0].innerHTML.match(/OC[A-Z0-9]{1,6}/)[0];
-            $('#mapinfowindow table.mappopup tbody').append('<tr id="s2cg"><td colspan="3"></td></tr>');
-            buildButton(OCCode, $('#s2cg td'), '16px');
-            $('#s2cg td a').append('<span>An c:geo senden</span>')
-
-            // continue observing
-            observer.observe(target, config);
-        }
-
-        // observer callback
-        let cb = function() {
-            // add buttons if table has been loaded
-            if ($('#mapinfowindow table.mappopup tbody')[0] && !$('#s2cg')[0]) {
-                addButton();
-            }
-        }
-
-        // observe body for changes of child nodes
-        let target = $('body')[0];
-        let config = {
-            childList: true,
-            subtree: true
-        };
-        let observer = new MutationObserver(cb);
-        observer.observe(target, config);
+    function closePupup() {
+        $('#s2cg_popup').css('display', 'none');
     }
-
 // This will add settings
     function save_settings() {
         GM_setValue('useWithoutThirdPartyCookies', $('#useWithoutThirdPartyCookies').is(':checked'));
@@ -671,11 +645,11 @@ function s2cgGCMain() {
              + '        <input type="checkbox" id="' + id + '"' + (GM_getValue(id, false) ? ' checked' : '') + '><span class="slider"></span>'
              + '    </label>'
              + (info != ''
-                ? '    <label for="' + id + '_info" class="s2cg_infoBtn"> ?</label>'
+                ? '    <label for="' + id + '_info" class="s2cg_btn_info"> ?</label>'
                 + '    <input type="checkbox" id="' + id + '_info" class="s2cg_info">'
                 + '    <div class="s2cg_info">' + info + '</div>'
                 : '')
-             + '</div>'
+             + '</div>';
     }
 
     // Long info text
@@ -687,19 +661,27 @@ function s2cgGCMain() {
                               + '<b>Attention: Sending multiple Caches does not work on the search page </b>'
                               + '(https://www.geocaching.com/play/search)';
 
-    var settingsHTML = '<div id="send2cgeo_settings" style="display:none;">'
-                     + '    <div id="s2cg_settings_content">'
-                     + '        <div id="s2cg_settings_header">'
-                     + '            <h1>Send to c:geo settings</h1>'
-                     + '        </div>'
-                     // Add options
-                     + buildToggle('useWithoutThirdPartyCookies', 'Use Send to c:geo without third-party cookies', thirdPartyCookiesInfo)
-                     // Save-Button
-                     + '            <input type="button" id="send2cgeo_settings_submit" value="Save">'
-                     + '    </div>'
-                     + '</div>';
+    function getSettingsHTML() {
+        return '<div id="s2cg_popup_close">X</div>'
+             + '<div id="s2cg_popup_header">'
+             + '    <h1>Send to c:geo settings</h1>'
+             + '</div>'
+             // Add options
+             + buildToggle('useWithoutThirdPartyCookies', 'Use Send to c:geo without third-party cookies', thirdPartyCookiesInfo)
+             // Save-Button
+             + '<input type="button" id="s2cg_settings_submit" class="s2cg_btn_submit" value="Save">';
+    }
 
-    var settingsCSS = '#send2cgeo_settings {'
+    var sendMultipleHTML = '<div id="s2cg_popup_close">X</div>'
+                         + '<div id="s2cg_popup_header">'
+                         + '    <h1>Send Multiple Caches</h1>'
+                         + '</div>'
+                         + '<textarea id="s2cg_send_input"></textarea>'
+                         + '<div id="s2cg_send_process"></div>'
+                         + '<div id="s2cg_send_frames" style="display:none;"></div>'
+                         + '<input type="button" id="s2cg_send_submit" class="s2cg_btn_submit" value="Send">';
+
+    var settingsCSS = '#s2cg_popup {'
                     + '    position: fixed;'
                     + '    background: rgba(31, 31, 31, .7);'
                     + '    top: 0;'
@@ -710,7 +692,15 @@ function s2cgGCMain() {
                     + '    color: #fff;'
                     + '}'
 
-                    + '#s2cg_settings_content {'
+                    + '#s2cg_popup_close {'
+                    + '    position:absolute;'
+                    + '    top:10px;'
+                    + '    right:10px;'
+                    + '    font-weight: bold;'
+                    + '    cursor: pointer;'
+                    + '}'
+
+                    + '#s2cg_popup_content {'
                     + '    position: absolute;'
                     + '    top: 50%;'
                     + '    left: 50%;'
@@ -723,11 +713,17 @@ function s2cgGCMain() {
                     + '    border-radius: 1em;'
                     + '}'
 
-                    + '#s2cg_settings_content p, .s2cg_toggle label, #send2cgeo_settings_submit {'
+                    + '#s2cg_send_input {'
+                    + '    color:#000;'
+                    + '    width:100%;'
+                    + '    min-height:200px;'
+                    + '}'
+
+                    + '#s2cg_popup_content p, .s2cg_toggle label, .s2cg_btn_submit, #s2cg_send_input, #s2cg_send_process, #s2cg_popup_close {'
                     + '    font-size: ' + (document.location.href.match(/\.de\/myhome\.php/) ? '1.5' : '1') + 'em !important;'
                     + '}'
 
-                    + '#send2cgeo_settings_submit {'
+                    + '.s2cg_btn_submit {'
                     + '    margin-top: 1em;'
                     + '    color: rgba(31, 31, 31, 1);'
                     + '    border-radius: 5px;'
@@ -794,7 +790,7 @@ function s2cgGCMain() {
                     + '    margin: 0 0 1em 1.5em;'
                     + '}'
 
-                    + '.s2cg_infoBtn {'
+                    + '.s2cg_btn_info {'
                     + '    cursor:pointer;'
                     + '    margin-left:3em;'
                     + '    border:2px solid #fff;'
@@ -806,38 +802,55 @@ function s2cgGCMain() {
                     + '    box-sizing: border-box;'
                     + '}'
 
-                    + '.s2cg_infoBtn:hover {'
+                    + '.s2cg_btn_info:hover {'
                     + '    background: #9f9f9f;'
                     + '}';
 
     if (document.location.href.match(/\.com\/account\/dashboard/) || document.location.href.match(/\.com\/my\/default.aspx/) || document.location.href.match(/\.de\/myhome\.php/)) {
         $('head').append('<style>' + settingsCSS + '</style>');
-        $('body').append(settingsHTML);
+        $('body').append(popupHTML);
         // geocaching.com
         // new Dashboard
         if (document.location.href.match(/\.com\/account\/dashboard/)) {
-            $('.bio-meta').append('<a id="s2cg_openSettings" href="javascript:void(0)" style="display:block;">Send to c:geo settings</a>');
+            $('.bio-meta').append('<span style="display:block;">Send to c:geo <a id="s2cg_open_settings" href="javascript:void(0)">Settings</a> | <a id="s2cg_open_sendList" href="javascript:void(0)">Send List</a></span>');
         }
         // new Dashboard
         if (document.location.href.match(/\.com\/my\/default.aspx/)) {
-            $('#ctl00_ContentBody_WidgetMiniProfile1_memberProfileLink').parent().append(' | <a id="s2cg_openSettings" href="javascript:void(0)">Send to c:geo settings</a>');
+            $('#ctl00_ContentBody_WidgetMiniProfile1_memberProfileLink').parent().append(' | Send to c:geo <a id="s2cg_open_settings" href="javascript:void(0)">Settings</a> | <a id="s2cg_open_sendList" href="javascript:void(0)">Send List</a>');
         }
         // opencaching.de
         if (document.location.href.match(/\.de\/myhome\.php/)) {
         $('.content2-pagetitle').after('<div class="content2-container bg-blue02" style="margin-top:20px;">'
                                        + '    <p class="content-title-noshade-size3">'
                                        + '        <img src="https://www.cgeo.org/send2cgeo.png" style="margin-right:10px;" height="22px" />'
-                                       + '        Send to c:geo <span class="content-title-link"><a id="s2cg_openSettings" href="javascript:void(0)">Settings</a></span>'
+                                       + '        Send to c:geo <span class="content-title-link"><a id="s2cg_open_settings" href="javascript:void(0)">Settings</a> | <a id="s2cg_open_sendList" href="javascript:void(0)">Send List</a></span>'
                                        + '    </p>'
                                        + '</div>');
         }
         // Open and Save settings
-        $('#s2cg_openSettings').on('click', function() {
-            $('#send2cgeo_settings').css('display', 'unset');
+        $('#s2cg_open_settings').on('click', function() {
+            $('#s2cg_popup_content').html(getSettingsHTML());
+            $('#s2cg_popup').css('display', 'unset');
+            $('#s2cg_settings_submit').on('click', function() {
+                save_settings();
+                closePupup();
+            });
+            $('#s2cg_popup_close').on('click', closePupup);
         });
-        $('#send2cgeo_settings_submit').on('click', function() {
-            save_settings();
-            $('#send2cgeo_settings').css('display', 'none');
+        // Open and Send multiple caches
+        $('#s2cg_open_sendList').on('click', function() {
+            $('#s2cg_popup_content').html(sendMultipleHTML);
+            $('#s2cg_popup').css('display', 'unset');
+            $('#s2cg_send_submit').on('click', function() {
+                var gccodes = $('#s2cg_send_input').val().match(/(GC|OC)[A-Z0-9]{1,6}/gi);
+                $(gccodes).each(
+                    function () {
+                        $('#s2cg_send_frames').append('<div><span id="s2cg-' + this + '"></span></div>');
+                    }
+                );
+                sendList(gccodes);
+            });
+            $('#s2cg_popup_close').on('click', closePupup);
         });
     }
 }


### PR DESCRIPTION
- sending gccode lists (fix #14, fix #50)
- rewriting send multiple caches on the search page (fix #78)
- fix: If you open the CO dashboard at https://www.geocaching.com/play/owner and open the lists from there, the s2cg buttons were not added.
- fix #120 
- Close Button on Settings Popup
- use .match() instead of long .subsr() and .indexOf() combinations.
- some naming