### PR TITLE
Remove Warning, that s2cg not work on searchpage

### DIFF
--- a/send2cgeo.user.js
+++ b/send2cgeo.user.js
@@ -658,7 +658,6 @@ function s2cgGCMain() {
                               + 'cookies on geocaching.com and opencaching.de and is therefore a third-party cookie.'
                               + '<br>With this option, the cookies are not set via the geocaching.com and opencaching.de '
                               + 'pages, but in a pop-up window so that you can continue to use "Send to c:geo".<br>'
-                              + '<b>Attention: Sending multiple Caches does not work on the search page </b>'
                               + '(https://www.geocaching.com/play/search)';
 
     function getSettingsHTML() {


### PR DESCRIPTION
If you use s2gc with third-party cookies the multiple sending does not work on searchpage. That is fixed with #124 but I forgot to remove the warning in the settings.