### PR TITLE
Problems between GClh and Send to c:geo

### DIFF
--- a/send2cgeo.user.js
+++ b/send2cgeo.user.js
@@ -322,7 +322,10 @@ function s2cgGCMain() {
 
         // observer callback for checking existence of sidebar
         var cb_body = function(mutationsList, observer) {
+            observer_body.disconnect();
+
             addButtonPopup();
+
             if ($('div#sidebar')[0] && !$('.s2cg_sidebar_observer')[0]) {
                 $('div#sidebar').addClass('s2cg_sidebar_observer');
                 // start observing sidebar for switches between search list and cache details view
@@ -333,6 +336,8 @@ function s2cgGCMain() {
                 };
                 observer_sidebar.observe(target_sidebar, config_sidebar);
             }
+
+            observer_body.observe(target_body, config_body);
         }
 
         // observer callback when sidebar switches between search list and cache details view
@@ -597,7 +602,7 @@ function s2cgGCMain() {
 
 // This function add the send2cgeo buttons on opencaching.de
     // Send to c:geo on viewcache
-    if(document.location.href.match(/\.de\/viewcache\.php/)) {
+    if (document.location.href.match(/\.de\/viewcache\.php/)) {
         var oc = document.getElementsByClassName('exportlist')[0].parentNode.parentNode;
         var occode = document.title.match(/OC[A-Z0-9]{1,6}/)[0];
 

--- a/send2cgeo.user.js
+++ b/send2cgeo.user.js
@@ -297,9 +297,10 @@ function s2cgGCMain() {
                 function () {
                     if ($('.leaflet-popup-content')[0]) {
                         var GCCode = $('.cache-action-open-cache')[0].href.match(/GC[A-Z0-9]{1,6}/);
+                        if ($('#s2cg_' + GCCode)[0]) return;
                         // Remove button when the GCCode has change
                         removeIfAlreadyExists('.cache-action-menu-view ul li.s2cg', $('.cache-action-menu-view ul li.s2cg'));
-                        $('.cache-action-menu-view ul').append('<li class="s2cg"></li>');
+                        $('.cache-action-menu-view ul').append('<li id="s2cg_' + GCCode + '" class="s2cg"></li>');
                         buildButton(GCCode, $('.cache-action-menu-view ul li.s2cg'), '0', 'hidden');
                         $('.cache-action-menu-view ul li.s2cg a').append('<span>Send to c:geo</span>');
                     }
@@ -313,8 +314,9 @@ function s2cgGCMain() {
             if ($('.cache-preview-action-menu')[0]) {
                 var GCCode = $('.cache-metadata-code').html();
                 // Remove button when the GCCode has change
+                if ($('#s2cg_' + GCCode)[0]) return;
                 removeIfAlreadyExists('.cache-preview-action-menu ul li.s2cg', $('.cache-preview-action-menu ul li.s2cg'));
-                $('.cache-preview-action-menu ul').append('<li class="s2cg"></li>');
+                $('.cache-preview-action-menu ul').append('<li id="s2cg_' + GCCode + '" class="s2cg"></li>');
                 buildButton(GCCode, $('.cache-preview-action-menu ul li.s2cg'), '25px', 'action-icon');
                 $('.cache-preview-action-menu ul li.s2cg a').append('<span>Send to c:geo</span>');
             }


### PR DESCRIPTION
fix https://github.com/2Abendsegler/GClh/issues/1796

Because we didn't check whether the gc code had changed, but generally removed the button and added a new one, we triggered the observer of the GClh every time, which in turn triggered our observer. That led to an infinite loop.
This error only seems to be a problem since the last Firefox update.