### PR TITLE
The "Send List" link appears multiple times in new dashboard

### DIFF
--- a/send2cgeo.user.js
+++ b/send2cgeo.user.js
@@ -630,7 +630,7 @@ function s2cgGCMain() {
         // geocaching.com
         // new Dashboard
         if (document.location.href.match(/\.com\/account\/dashboard/)) {
-            $('.bio-meta').append('<span style="display:block;">Send to c:geo <a id="s2cg_open_sendList" href="javascript:void(0)">Send List</a></span>');
+            $('.bio-meta:first').append('<span style="display:block;">Send to c:geo <a id="s2cg_open_sendList" href="javascript:void(0)">Send List</a></span>');
         }
         // old Dashboard
         if (document.location.href.match(/\.com\/my\/default.aspx/)) {


### PR DESCRIPTION
After an [update to the new dashboard website](https://forums.geocaching.com/GC/index.php?/topic/418930-release-notes-website-player-dashboard-updates-february-12-2025/#findComment-6200749), the "Send List" link appears multiple times.

To Reproduce:  https://www.geocaching.com/account/dashboard

Before change:
![before](https://github.com/user-attachments/assets/f5245542-922d-4cf9-a780-4f7b84237cd9)

After change:
![after](https://github.com/user-attachments/assets/a3f2cf70-7d1e-4553-aa46-ebfb5f66f148)

Tested with premium and basic member.
Tested together with GC little helper II and without.


